### PR TITLE
Add option to initialize a SSH config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # slist
-![version](https://img.shields.io/github/release/GovTechSG/slist.svg?style=flat)
+![version](https://img.shields.io/github/release/GovTechSG/slist.svg?style=flat) [![Build Status](https://travis-ci.org/GovTechSG/slist.svg?branch=master)](https://travis-ci.org/GovTechSG/slist)
 
 slist is a tool to list your servers in ssh config and ssh into it.<br/>
 This only works on Unix machines.<br/>

--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ Usage: slist [-fhl]
 --keypath <keyname_with_path>   Add a new key file to SSH config file. Must be used together with --add-host and --ip-adr options
 --del-host <host_name>          Delete a host from the SSH config file
 --config-file                   To use other config file
+--init <file_path>              To initialize a template SSH config file
 ```

--- a/slist.sh
+++ b/slist.sh
@@ -264,11 +264,25 @@ create_template() {
   filePath="$1"
 
   cat > "$filePath" << EOF
-  Host <your_host>
-    User <your_user>
-    HostName <ip_address>
-    Port 22
-    IdentityFile <path_to_private_key>
+# If you have a jump host
+Host jumpHost
+  User <your_user>
+  HostName <ip_address>
+  Port 22
+  IdentityFile <path_to_private_key>
+
+Host <your_host>
+  User <your_user>
+  HostName <ip_address>
+  ProxyCommand ssh -A jumpHost nc %h %p   # If you want to use the jumpHost to connect to the host
+  Port 22
+  IdentityFile <path_to_private_key>
+
+Host <your_host2>
+  User <your_user2>
+  HostName <ip_address2>
+  Port 22
+  IdentityFile <path_to_private_key>
 EOF
 
   printf "%s\n" "${green}Template SSH config created at $filePath ${end}"


### PR DESCRIPTION
For #14 

Test cases:
1. `slist --init`
1. `slist --init <file_path_that_already_exists>`
    1. Overwrite? y
    1. Overwrite? n
1. `slist --init <new_file_path>