### PR TITLE
Specify config file for ssh

### DIFF
--- a/slist.sh
+++ b/slist.sh
@@ -94,7 +94,7 @@ main() {
     fi
 
     host=$(grep "^$cs " ${list_path} | awk '{print $2}')
-    ssh "$host"
+    ssh -F "$config_file" "$host"
     exit
 }
 


### PR DESCRIPTION
I have 2 ssh config files (config and config-bgp). both have gms-apache as Host but different ip addresses. when i do slist --config-file ~/.ssh/config-bgp it lists correctly but when choose server to connect, it connects to the wrong ip address