### PR TITLE
Use -F option when ssh to host from filtered list

### DIFF
--- a/slist.sh
+++ b/slist.sh
@@ -149,7 +149,7 @@ filter() {
     fi
 
     host=$(grep "^$cs " ${list_path} | awk '{print $2}')
-    ssh "$host"
+    ssh -F "$config_file" "$host"
     exit
 }
 


### PR DESCRIPTION
Test case: `slist --config-file <another_config_file> -f <keyword>`
Problem was that without the -F option for ssh, slist was trying to establish connection to the wrong host from the wrong config file