### PR TITLE
Option for persistent color changes

### DIFF
--- a/slist.sh
+++ b/slist.sh
@@ -43,8 +43,8 @@ Initialising a template SSH config file.
 Usage: slist --init <file path>
 
 To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile or .bash_profile.
-export color1=cyan
-export color2=yellow
+export color_theme1=cyan
+export cocolor_theme2=yellow
 
 Supported colors:
 ${black}black${end} ${red}red${end} ${green}green${end} ${yellow}yellow${end} ${blue}blue${end} ${pink}pink${end} ${cyan}cyan${end} ${white}white${end}

--- a/slist.sh
+++ b/slist.sh
@@ -42,7 +42,7 @@ Usage: slist --del-host <host name>
 Initialising a template SSH config file.
 Usage: slist --init <file path>
 
-To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile.
+To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile or ..bash_profile.
 export color1=cyan
 export color2=yellow
 

--- a/slist.sh
+++ b/slist.sh
@@ -42,7 +42,7 @@ Usage: slist --del-host <host name>
 Initialising a template SSH config file.
 Usage: slist --init <file path>
 
-To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile or ..bash_profile.
+To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile or .bash_profile.
 export color1=cyan
 export color2=yellow
 

--- a/slist.sh
+++ b/slist.sh
@@ -14,10 +14,6 @@ cyan=$'\e[0;36m'
 white=$'\e[0;37m'
 end=$'\e[0m'
 
-# slist color template (Change this to change slist output colors)
-color1="$blue"
-color2="$pink"
-
 # Function for printing usage
 usage() { echo "Usage: $0 [-p <filler word>]" 1>&2; exit 1; }
 
@@ -35,16 +31,23 @@ Usage: slist [-hl]|[-f <keyword>]
 Using other conf instead of default ~/.ssh/conf
 Usage: slist --file /tmp/config
 
-Adding new host to ssh config
+Adding new host to ssh config.
 Usage: slist --add-host <host name> --ip-adr <ip address> --ssh-user <user> --port <port number> --keypath < keyname with path >
 
 Only --add-host and --ip-adr are mandatory to have
 
-Delete host from ssh config
+Delete host from ssh config.
 Usage: slist --del-host <host name>
 
-Initialising a template SSH config file
+Initialising a template SSH config file.
 Usage: slist --init <file path>
+
+To make persistent color change to slist theme. Add below 2 lines to .bashrc or .profile.
+export color1=cyan
+export color2=yellow
+
+Supported colors:
+${black}black${end} ${red}red${end} ${green}green${end} ${yellow}yellow${end} ${blue}blue${end} ${pink}pink${end} ${cyan}cyan${end} ${white}white${end}
 
 EOF
 exit;
@@ -245,8 +248,58 @@ EOF
   exit 0
 }
 
+# Function to check if colors variable are declared.
+check_colors () {
+  if [ -z "$color_theme1" ]; then
+    color_theme1=blue
+  fi
+
+  if [ -z "$color_theme2" ]; then
+    color_theme2=pink
+  fi
+}
+
+# Function to match color with declare variable
+color_match () {
+  case "$1" in
+    black)
+      color="$black"
+      ;;
+    red)
+      color="$red"
+      ;;
+    green)
+      color="$green"
+      ;;
+    yellow)
+      color="$yellow"
+      ;;
+    blue)
+      color="$blue"
+      ;;
+    pink)
+      color="$pink"
+      ;;
+    cyan)
+      color="$cyan"
+      ;;
+    white)
+      color="$white"
+      ;;
+    *)
+      printf "${red}Invalid${end} ${1} for ${2} \n"
+      printf "%s\n" "Chose only this colors ${black}black${end} ${red}red${end} ${green}green${end} ${yellow}yellow${end} ${blue}blue${end} ${pink}pink${end} ${cyan}cyan${end} ${white}white${end}"
+      exit;
+  esac
+}
+
 # Start of slist
 check_config_file_exists
+check_colors
+color_match "$color_theme1" color_theme1
+color1=$color
+color_match "$color_theme2" color_theme2
+color2=$color
 
 list=false
 filter=false

--- a/slist.sh
+++ b/slist.sh
@@ -287,7 +287,7 @@ color_match () {
       color="$white"
       ;;
     *)
-      printf "${red}Invalid${end} ${1} for ${2} \n"
+      printf "%s\n" "${red}Invalid${end} ${1} for ${2}"
       printf "%s\n" "Chose only this colors ${black}black${end} ${red}red${end} ${green}green${end} ${yellow}yellow${end} ${blue}blue${end} ${pink}pink${end} ${cyan}cyan${end} ${white}white${end}"
       exit;
   esac


### PR DESCRIPTION
Allow persistent colour theme changes by declaring variable.

Example is to add below 2 lines to .bashrc or .profile.
export color_theme1=cyan
export color_theme2=yellow

slist will read this variable and determine the colours with this variables.
If both variable not declare, default colours will be use.